### PR TITLE
Remove deprecated App Insights output (propagation from #18)

### DIFF
--- a/.propagation/infra-eval-20250809T235750Z.json
+++ b/.propagation/infra-eval-20250809T235750Z.json
@@ -1,0 +1,1 @@
+{"sourcePr":"https://github.com/Azure-Samples/functions-quickstart-dotnet-azd/pull/18","evaluation":"no-op","checked":["infra/main.bicep"],"reason":"output absent","timestamp":"2025-08-09T23:57:50Z"}

--- a/.propagation/infra-eval-20250810T000349Z.json
+++ b/.propagation/infra-eval-20250810T000349Z.json
@@ -1,0 +1,1 @@
+{"sourcePr":"https://github.com/Azure-Samples/functions-quickstart-dotnet-azd/pull/18","evaluation":"no-op","checked":["infra/main.bicep"],"reason":"output absent","timestamp":"2025-08-10T00:03:49Z"}

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -226,7 +226,6 @@ module monitoring 'br/public:avm/res/insights/component:0.6.0' = {
 }
 
 // App outputs
-output APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.connectionString
 output AZURE_LOCATION string = location
 output AZURE_TENANT_ID string = tenant().tenantId
 output SERVICE_API_NAME string = api.outputs.SERVICE_API_NAME


### PR DESCRIPTION
Removes the deprecated APPLICATIONINSIGHTS_CONNECTION_STRING output from infra/main.bicep per https://github.com/Azure-Samples/functions-quickstart-dotnet-azd/pull/18

This change aligns the template with the source PR which removed this deprecated output pattern across Azure Functions AZD templates.