### PR TITLE
Add azd-service-name tag to function app parameters

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -106,7 +106,9 @@ module api './app/api.bicep' = {
   params: {
     name: functionAppName
     location: location
-    tags: tags
+    tags: union(tags, {
+      'azd-service-name': 'api'
+    })
     applicationInsightsName: monitoring.outputs.name
     appServicePlanId: appServicePlan.outputs.resourceId
     runtimeName: 'node'


### PR DESCRIPTION
Missing tag for azd to know where to deploy

